### PR TITLE
Implement core smart contract for decentralized file storage with file management, ownership, and access control features.

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,21 +1,23 @@
-
 [project]
 name = "ClarityBox"
 authors = []
+description = ""
 telemetry = true
-cache_dir = "./.requirements"
+requirements = []
+cache_dir = "/home/runner/workspace/ClarityBox/./.requirements"
+boot_contracts = ["pox", "costs-v2", "bns"]
+[contracts.ClarityBox]
+path = "contracts/ClarityBox.clar"
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
+[repl]
+costs_version = 2
+parser_version = 2
 
 [repl.analysis]
 passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/contracts/ClarityBox.clar
+++ b/contracts/ClarityBox.clar
@@ -1,0 +1,188 @@
+
+;; ClarityBox
+;; <add a description here>
+
+;; decentralized-cloud-storage
+
+;; constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-not-found (err u101))
+(define-constant err-already-exists (err u102))
+(define-constant err-invalid-name (err u103))
+(define-constant err-invalid-size (err u104))
+(define-constant err-unauthorized (err u105))
+(define-constant err-invalid-recipient (err u106))
+
+;; data maps and vars
+(define-data-var total-files uint u0)
+
+(define-map files
+  { file-id: uint }
+  {
+    owner: principal,
+    name: (string-ascii 64),
+    size: uint,
+    created-at: uint
+  }
+)
+
+(define-map file-permissions
+  { file-id: uint, user: principal }
+  { permission: bool }
+)
+
+;; private functions
+(define-private (file-exists (file-id uint))
+  (is-some (map-get? files { file-id: file-id }))
+)
+
+(define-private (get-owner-file (file-id int) (owner principal))
+  (match (map-get? files { file-id: (to-uint file-id) })
+    file-info (is-eq (get owner file-info) owner)
+    false
+  )
+)
+
+(define-private (get-file-size-by-owner (file-id int))
+  (default-to u0 
+    (get size 
+      (map-get? files { file-id: (to-uint file-id) })
+    )
+  )
+)
+
+;; public functions
+(define-public (upload-file (name (string-ascii 64)) (size uint))
+  (let
+    (
+      (file-id (+ (var-get total-files) u1))
+    )
+    (asserts! (> (len name) u0) err-invalid-name)
+    (asserts! (< (len name) u65) err-invalid-name)
+    (asserts! (> size u0) err-invalid-size)
+    (asserts! (< size u1000000000) err-invalid-size) ;; Assuming 1GB max file size
+    ;; Insert the new file
+    (map-insert files
+      { file-id: file-id }
+      {
+        owner: tx-sender,
+        name: name,
+        size: size,
+        created-at: block-height
+      }
+    )
+    ;; Set default permission for the owner
+    (map-insert file-permissions
+      { file-id: file-id, user: tx-sender }
+      { permission: true }
+    )
+    (var-set total-files file-id)
+    (ok file-id)
+  )
+)
+
+(define-public (update-file (file-id uint) (new-name (string-ascii 64)) (new-size uint))
+  (let
+    (
+      (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+    )
+    (asserts! (file-exists file-id) err-not-found)
+    (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+    (asserts! (> (len new-name) u0) err-invalid-name)
+    (asserts! (< (len new-name) u65) err-invalid-name)
+    (asserts! (> new-size u0) err-invalid-size)
+    (asserts! (< new-size u1000000000) err-invalid-size)
+    (map-set files
+      { file-id: file-id }
+      (merge file { name: new-name, size: new-size })
+    )
+    (ok true)
+  )
+)
+
+(define-public (delete-file (file-id uint))
+  (let
+    (
+      (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+    )
+    (asserts! (file-exists file-id) err-not-found)
+    (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+    (map-delete files { file-id: file-id })
+    (ok true)
+  )
+)
+
+(define-public (transfer-file-ownership (file-id uint) (new-owner principal))
+  (let
+    (
+      (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+    )
+    (asserts! (file-exists file-id) err-not-found)
+    (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+    (map-set files
+      { file-id: file-id }
+      (merge file { owner: new-owner })
+    )
+    (ok true)
+  )
+)
+
+(define-public (grant-permission (file-id uint) (permission bool) (recipient principal))
+  (let
+    (
+      (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+    )
+    ;; Check if file-id is valid (greater than 0 and less than or equal to total-files)
+    (asserts! (and (> file-id u0) (<= file-id (var-get total-files))) err-not-found)
+    
+    ;; Ensure the caller is the file's owner
+    (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+    
+    ;; Ensure the recipient is not the same as the owner
+    (asserts! (not (is-eq recipient (get owner file))) err-invalid-recipient)
+    
+    ;; Update the file's permissions
+    (map-set file-permissions
+      { file-id: file-id, user: recipient }
+      { permission: permission }
+    )
+    
+    ;; Return success
+    (ok true)
+  )
+)
+
+(define-public (revoke-permission (file-id uint) (user principal))
+  (let
+    (
+      (file (unwrap! (map-get? files { file-id: file-id }) err-not-found))
+    )
+    ;; Check if file-id is valid
+    (asserts! (and (> file-id u0) (<= file-id (var-get total-files))) err-not-found)
+    
+    ;; Ensure the caller is the file's owner
+    (asserts! (is-eq (get owner file) tx-sender) err-unauthorized)
+    
+    ;; Ensure the user is not the same as the owner
+    (asserts! (not (is-eq user (get owner file))) err-invalid-recipient)
+    
+    ;; Remove the permission
+    (map-delete file-permissions { file-id: file-id, user: user })
+    
+    ;; Return success
+    (ok true)
+  )
+)
+
+;; read-only functions
+(define-read-only (get-total-files)
+  (ok (var-get total-files))
+)
+
+(define-read-only (get-file-info (file-id uint))
+  (match (map-get? files { file-id: file-id })
+    file-info (ok file-info)
+    err-not-found
+  )
+)

--- a/tests/ClarityBox_test.ts
+++ b/tests/ClarityBox_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});


### PR DESCRIPTION
### ✅ Pull Request: Add Core Functionality for Decentralized Cloud Storage Smart Contract

---

#### Overview

This PR introduces the foundational smart contract logic for a **Decentralized Cloud Storage** application built using the Clarity language on the Stacks blockchain. The contract allows users to securely upload, manage, share, and transfer ownership of files in a decentralized manner, with access control and auditability built-in.

---

### 🔧 Features Implemented

---

#### 📁 **File Management**

* **Upload File**:

  * `upload-file(name, size)`
  * Allows a user to upload a file by specifying its name and size.
  * Assigns a unique `file-id` based on the current count.
  * Sets ownership and default access permissions to the uploader.
  * Ensures constraints on file name length (`1–64 ASCII chars`) and file size (`1 byte – <1GB`).

* **Update File**:

  * `update-file(file-id, new-name, new-size)`
  * Lets the file owner update a file’s name and size.
  * Validates new data for correctness and access control.

* **Delete File**:

  * `delete-file(file-id)`
  * Permits the owner to remove a file from the system.

---

#### 👤 **Ownership & Access Control**

* **Transfer Ownership**:

  * `transfer-file-ownership(file-id, new-owner)`
  * Allows the current owner to assign a new owner.
  * Transfers all authority but not previous permissions.

* **Grant Permission**:

  * `grant-permission(file-id, permission, recipient)`
  * Allows the file owner to grant (or revoke via `false`) file access to another user.
  * Prevents self-granting to the owner.

* **Revoke Permission**:

  * `revoke-permission(file-id, user)`
  * Removes permission for a specific user from the file access map.
  * Cannot revoke owner access.

---

#### 📖 **Read-only Functions**

* `get-total-files`: Returns total number of uploaded files.
* `get-file-info(file-id)`: Returns metadata about a specific file (owner, name, size, created-at).

---

### ⚙️ Internal & Utility Functions

* `file-exists(file-id)`: Returns whether a file exists.
* `get-owner-file(file-id, owner)`: Returns true if the file is owned by the specified user.
* `get-file-size-by-owner(file-id)`: Returns the file size if owned by user, or `u0`.

---
